### PR TITLE
fix: macro predefines to fix missing methods

### DIFF
--- a/scripts/Doxyfile
+++ b/scripts/Doxyfile
@@ -237,7 +237,9 @@ EXPAND_ONLY_PREDEF      = NO
 SEARCH_INCLUDES         = YES
 INCLUDE_PATH            =
 INCLUDE_FILE_PATTERNS   =
-PREDEFINED              =
+PREDEFINED              = "ECSACT_IMPORT(x)= " \
+                          "ECSACT_EXPORT(x)= " \
+                          "ECSACT_EXTERN"
 EXPAND_AS_DEFINED       =
 SKIP_FUNCTION_MACROS    = NO
 TAGFILES                =


### PR DESCRIPTION
| before | after |
|--------|-------|
| ![image](https://github.com/ecsact-dev/website/assets/1284289/4557c779-0ada-4c3a-a3d7-6695f4b14fb4) | ![image](https://github.com/ecsact-dev/website/assets/1284289/1eb796c7-b48f-4fea-a954-4dd28b91e3b1)


